### PR TITLE
allow to overwrite the config settings from within a page

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -172,6 +172,21 @@ class renderer_plugin_latexit extends Doku_Renderer {
     }
 
     /**
+     * Allow overwriting options from within the document
+     *
+     * @param string $setting
+     * @param bool   $notset
+     * @return mixed
+     */
+    function getConf($setting, $notset = false) {
+        global $ID;
+        $opts = p_get_metadata($ID, 'plugin_latexit');
+        if($opts && isset($opts[$setting])) return $opts[$setting];
+
+        return parent::getConf($setting, $notset);
+    }
+
+    /**
      * function is called, when a document is started to being rendered.
      * It inicializes variables, adds headers to the LaTeX document and
      * sets the browser headers of the exported file.

--- a/syntax/config.php
+++ b/syntax/config.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * DokuWiki Plugin latexit (Syntax Component)
+ *
+ * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
+ * @author  Andreas Gohr <gohr@cosmocode.de>
+ */
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
+
+/**
+ * Syntax component
+ *
+ * Allows per document reconfiguration
+ */
+class syntax_plugin_latexit_config extends DokuWiki_Syntax_Plugin {
+
+    /**
+     * @return string Syntax mode type
+     */
+    public function getType() {
+        return 'substition';
+    }
+
+    /**
+     * @return int Sort order - Low numbers go before high numbers
+     */
+    public function getSort() {
+        return 300;
+    }
+
+    /**
+     * Connect lookup pattern to lexer.
+     *
+     * @param string $mode Parser mode
+     */
+    public function connectTo($mode) {
+        $this->Lexer->addSpecialPattern('{{latexit[:>].+?}}', $mode, 'plugin_latexit_config');
+    }
+
+    /**
+     * Handle matches of the latexit syntax
+     *
+     * @param string       $match   The match of the syntax
+     * @param int          $state   The state of the handler
+     * @param int          $pos     The position in the document
+     * @param Doku_Handler $handler The handler
+     * @return array Data for the renderer
+     */
+    public function handle($match, $state, $pos, &$handler) {
+        list($key, $val) = explode(' ', trim(substr($match, 10, -2)), 2);
+        $key = trim($key);
+        $val = trim($val);
+
+        return array($key, $val);
+    }
+
+    /**
+     * Store config in metadata
+     *
+     * @param string        $mode      Renderer mode (supported modes: xhtml)
+     * @param Doku_Renderer $renderer  The renderer
+     * @param array         $data      The data from the handler() function
+     * @return bool If rendering was successful.
+     */
+    public function render($mode, &$renderer, $data) {
+        if($mode != 'metadata') return false;
+
+        list($key, $val) = $data;
+        $renderer->meta['plugin_latexit'][$key] = $val;
+    }
+}


### PR DESCRIPTION
This makes it possible to set a different document class or other page
parameters for one page while others still use the default.

It might make sense to restrict which parameters may be overwritten
later.

There should also be some cleanup of user supplied values, but my LaTex is a bit to rusty to know what is allowed for the different settings.
