### PR TITLE
Made private function _latexSpecialChars public to allow usage in other plugins

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -1510,7 +1510,7 @@ class renderer_plugin_latexit extends Doku_Renderer {
      * @param string $text Text to be escaped.
      * @return string Escaped text.
      */
-    private function _latexSpecialChars($text) {
+    public function _latexSpecialChars($text) {
         //find only entities in TEXT, not in eg MathJax
         preg_match('#///ENTITYSTART///(.*?)///ENTITYEND///#si', $text, $entity);
         //replace classic LaTeX escape chars


### PR DESCRIPTION
See https://www.dokuwiki.org/plugin:keyboard for sample usage (still commented out as this pull request has not been accepted and published as new plugin)
