### PR TITLE
Fix cache invalidation and prevent PHP warning on Debian

### DIFF
--- a/action.php
+++ b/action.php
@@ -78,9 +78,10 @@ class action_plugin_latexit extends DokuWiki_Action_Plugin {
      * @param array $param event parameters
      */
     public function _purgeCache(Doku_Event &$event, $param) {
+        global $config_cascade;
         if ($event->data->mode == 'latexit') {
             //touching main config will make all cache invalid
-            touch(DOKU_INC . 'conf/local.php');
+            touch($config_cascade['main']['local'][0]);
         }
     }
 


### PR DESCRIPTION
Using this plugin pollutes our Apache error.log with the folowing
warning (shortend and line-breaks inserted):

-snip-
PHP Warning:  touch(): Unable to create file /usr/share/dokuwiki/conf/local.php
because No such file or directory in
/var/lib/dokuwiki/lib/plugins/latexit/action.php on line 83
-snap-

The problem is, that Debian package moves the configuration
directory out and thus the config file to touch is not where
expected when hardcoded.

This approach fixes this by using the (first) path from the global
configuration array.

(Since I'm new to dokuwiki, this might not be the finest solution,
however, it just works(tm) for me :-)

Signed-off-by: Michael Heimpold <michael.heimpold@i2se.com>