### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -28,7 +28,7 @@ class action_plugin_latexit extends DokuWiki_Action_Plugin {
      *
      * @param Doku_Event_Handler $controller DokuWiki's event controller object
      */
-    public function register(Doku_Event_Handler &$controller) {
+    public function register(Doku_Event_Handler $controller) {
         //call _purgeCache before using parser's cache
         $controller->register_hook('PARSER_CACHE_USE', 'BEFORE', $this, '_purgeCache');
         //call _setLatexitSort before initializing language (the very first event in DW)

--- a/syntax/base.php
+++ b/syntax/base.php
@@ -67,7 +67,7 @@ class syntax_plugin_latexit_base extends DokuWiki_Syntax_Plugin {
      * @param Doku_Handler    $handler The handler
      * @return array Data for the renderer
      */
-    public function handle($match, $state, $pos, &$handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         //parse citations from the text (this will be done by this plugin only for latex export)
         //FIXME cite in paper regex is from zotero plugin, it has to match exactly
         if (preg_match('/\\\cite(\[([a-zA-Z0-9 \.,\-:]*)\])?\{([a-zA-Z0-9\-:]*?)\}/', $match, $matches)) {
@@ -92,7 +92,7 @@ class syntax_plugin_latexit_base extends DokuWiki_Syntax_Plugin {
      * @param array          $data      The data from the handler() function
      * @return bool If rendering was successful.
      */
-    public function render($mode, &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         //this will count the level of an following header according to number of ~ used
         if(is_array($data)) {
 

--- a/syntax/config.php
+++ b/syntax/config.php
@@ -48,7 +48,7 @@ class syntax_plugin_latexit_config extends DokuWiki_Syntax_Plugin {
      * @param Doku_Handler $handler The handler
      * @return array Data for the renderer
      */
-    public function handle($match, $state, $pos, &$handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         list($key, $val) = explode(' ', trim(substr($match, 10, -2)), 2);
         $key = trim($key);
         $val = trim($val);
@@ -64,7 +64,7 @@ class syntax_plugin_latexit_config extends DokuWiki_Syntax_Plugin {
      * @param array         $data      The data from the handler() function
      * @return bool If rendering was successful.
      */
-    public function render($mode, &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         if($mode != 'metadata') return false;
 
         list($key, $val) = $data;

--- a/syntax/mathjax.php
+++ b/syntax/mathjax.php
@@ -115,7 +115,7 @@ class syntax_plugin_latexit_mathjax extends DokuWiki_Syntax_Plugin {
      * @param Doku_Handler    $handler The handler
      * @return array Data for the renderer
      */
-    public function handle($match, $state, $pos, &$handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         // Just pass it through...
         return $match;
     }
@@ -128,7 +128,7 @@ class syntax_plugin_latexit_mathjax extends DokuWiki_Syntax_Plugin {
      * @param array          $data      The data from the handler() function
      * @return bool If rendering was successful.
      */
-    public function render($mode, &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         if ($mode == 'latex') {
             $renderer->_mathMode($data);
             return true;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
